### PR TITLE
Refactor admin form inputs with reusable components and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/aspen_site/components/InputField.tsx
+++ b/aspen_site/components/InputField.tsx
@@ -1,0 +1,22 @@
+import { ChangeEvent } from 'react';
+
+interface InputFieldProps {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  type?: string;
+  required?: boolean;
+}
+
+export default function InputField({ value, onChange, placeholder, type = 'text', required }: InputFieldProps) {
+  return (
+    <input
+      className="block border mb-2 w-full p-2"
+      type={type}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      required={required}
+    />
+  );
+}

--- a/aspen_site/components/TextAreaField.tsx
+++ b/aspen_site/components/TextAreaField.tsx
@@ -1,0 +1,20 @@
+import { ChangeEvent } from 'react';
+
+interface TextAreaFieldProps {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder: string;
+  required?: boolean;
+}
+
+export default function TextAreaField({ value, onChange, placeholder, required }: TextAreaFieldProps) {
+  return (
+    <textarea
+      className="block border mb-2 w-full p-2"
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      required={required}
+    />
+  );
+}

--- a/aspen_site/next-env.d.ts
+++ b/aspen_site/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/aspen_site/pages/admin/index.tsx
+++ b/aspen_site/pages/admin/index.tsx
@@ -1,4 +1,15 @@
 import { useState, FormEvent } from 'react';
+import InputField from '../../components/InputField';
+import TextAreaField from '../../components/TextAreaField';
+
+function isValidUrl(url: string) {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function createItem(url: string, data: any) {
   await fetch(url, {
@@ -12,21 +23,51 @@ export default function Admin() {
   const [restaurant, setRestaurant] = useState({ name: '', description: '', location: '', url: '' });
   const [activity, setActivity] = useState({ name: '', description: '', location: '', url: '' });
   const [ad, setAd] = useState({ title: '', description: '', imageUrl: '', link: '' });
+  const [restaurantError, setRestaurantError] = useState('');
+  const [activityError, setActivityError] = useState('');
+  const [adError, setAdError] = useState('');
 
   const handleRestaurantSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (!restaurant.name || !restaurant.description || !restaurant.location || !restaurant.url) {
+      setRestaurantError('All fields are required');
+      return;
+    }
+    if (!isValidUrl(restaurant.url)) {
+      setRestaurantError('Website URL must be valid');
+      return;
+    }
+    setRestaurantError('');
     await createItem('/api/restaurants', restaurant);
     alert('Restaurant created');
   };
 
   const handleActivitySubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (!activity.name || !activity.description || !activity.location || !activity.url) {
+      setActivityError('All fields are required');
+      return;
+    }
+    if (!isValidUrl(activity.url)) {
+      setActivityError('Website URL must be valid');
+      return;
+    }
+    setActivityError('');
     await createItem('/api/activities', activity);
     alert('Activity created');
   };
 
   const handleAdSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (!ad.title || !ad.description || !ad.imageUrl || !ad.link) {
+      setAdError('All fields are required');
+      return;
+    }
+    if (!isValidUrl(ad.imageUrl) || !isValidUrl(ad.link)) {
+      setAdError('Image URL and Link must be valid URLs');
+      return;
+    }
+    setAdError('');
     await createItem('/api/advertisements', ad);
     alert('Advertisement created');
   };
@@ -38,10 +79,11 @@ export default function Admin() {
       <section className="mb-8">
         <h2 className="text-2xl font-semibold mb-2">Add Restaurant</h2>
         <form onSubmit={handleRestaurantSubmit}>
-          <input className="block border mb-2 w-full p-2" placeholder="Name" value={restaurant.name} onChange={e => setRestaurant({ ...restaurant, name: e.target.value })} />
-          <textarea className="block border mb-2 w-full p-2" placeholder="Description" value={restaurant.description} onChange={e => setRestaurant({ ...restaurant, description: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Location" value={restaurant.location} onChange={e => setRestaurant({ ...restaurant, location: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Website URL" value={restaurant.url} onChange={e => setRestaurant({ ...restaurant, url: e.target.value })} />
+          <InputField placeholder="Name" value={restaurant.name} onChange={e => setRestaurant({ ...restaurant, name: e.target.value })} required />
+          <TextAreaField placeholder="Description" value={restaurant.description} onChange={e => setRestaurant({ ...restaurant, description: e.target.value })} required />
+          <InputField placeholder="Location" value={restaurant.location} onChange={e => setRestaurant({ ...restaurant, location: e.target.value })} required />
+          <InputField type="url" placeholder="Website URL" value={restaurant.url} onChange={e => setRestaurant({ ...restaurant, url: e.target.value })} required />
+          {restaurantError && <p className="text-red-600 mb-2">{restaurantError}</p>}
           <button type="submit" className="px-4 py-2 bg-blue-600 text-white">Add Restaurant</button>
         </form>
       </section>
@@ -49,10 +91,11 @@ export default function Admin() {
       <section className="mb-8">
         <h2 className="text-2xl font-semibold mb-2">Add Activity</h2>
         <form onSubmit={handleActivitySubmit}>
-          <input className="block border mb-2 w-full p-2" placeholder="Name" value={activity.name} onChange={e => setActivity({ ...activity, name: e.target.value })} />
-          <textarea className="block border mb-2 w-full p-2" placeholder="Description" value={activity.description} onChange={e => setActivity({ ...activity, description: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Location" value={activity.location} onChange={e => setActivity({ ...activity, location: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Website URL" value={activity.url} onChange={e => setActivity({ ...activity, url: e.target.value })} />
+          <InputField placeholder="Name" value={activity.name} onChange={e => setActivity({ ...activity, name: e.target.value })} required />
+          <TextAreaField placeholder="Description" value={activity.description} onChange={e => setActivity({ ...activity, description: e.target.value })} required />
+          <InputField placeholder="Location" value={activity.location} onChange={e => setActivity({ ...activity, location: e.target.value })} required />
+          <InputField type="url" placeholder="Website URL" value={activity.url} onChange={e => setActivity({ ...activity, url: e.target.value })} required />
+          {activityError && <p className="text-red-600 mb-2">{activityError}</p>}
           <button type="submit" className="px-4 py-2 bg-blue-600 text-white">Add Activity</button>
         </form>
       </section>
@@ -60,10 +103,11 @@ export default function Admin() {
       <section>
         <h2 className="text-2xl font-semibold mb-2">Add Advertisement</h2>
         <form onSubmit={handleAdSubmit}>
-          <input className="block border mb-2 w-full p-2" placeholder="Title" value={ad.title} onChange={e => setAd({ ...ad, title: e.target.value })} />
-          <textarea className="block border mb-2 w-full p-2" placeholder="Description" value={ad.description} onChange={e => setAd({ ...ad, description: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Image URL" value={ad.imageUrl} onChange={e => setAd({ ...ad, imageUrl: e.target.value })} />
-          <input className="block border mb-2 w-full p-2" placeholder="Link" value={ad.link} onChange={e => setAd({ ...ad, link: e.target.value })} />
+          <InputField placeholder="Title" value={ad.title} onChange={e => setAd({ ...ad, title: e.target.value })} required />
+          <TextAreaField placeholder="Description" value={ad.description} onChange={e => setAd({ ...ad, description: e.target.value })} required />
+          <InputField type="url" placeholder="Image URL" value={ad.imageUrl} onChange={e => setAd({ ...ad, imageUrl: e.target.value })} required />
+          <InputField type="url" placeholder="Link" value={ad.link} onChange={e => setAd({ ...ad, link: e.target.value })} required />
+          {adError && <p className="text-red-600 mb-2">{adError}</p>}
           <button type="submit" className="px-4 py-2 bg-blue-600 text-white">Add Advertisement</button>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- add reusable `InputField` and `TextAreaField` components
- refactor admin dashboard forms to use shared components
- implement simple client-side validation with user error feedback

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: Cannot find module '../../../lib/prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68be3d0c31c083229d352dcc5d9610a3