### PR TITLE
Add error handling for Prisma API routes

### DIFF
--- a/aspen_site/pages/api/activities.ts
+++ b/aspen_site/pages/api/activities.ts
@@ -1,16 +1,26 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    const activities = await prisma.activity.findMany();
-    return res.status(200).json(activities);
+    try {
+      const activities = await prisma.activity.findMany();
+      return res.status(200).json(activities);
+    } catch (error) {
+      console.error('Error fetching activities:', error);
+      return res.status(500).json({ message: 'Failed to fetch activities' });
+    }
   } else if (req.method === 'POST') {
-    const { name, description, location, url } = req.body;
-    const activity = await prisma.activity.create({
-      data: { name, description, location, url }
-    });
-    return res.status(201).json(activity);
+    try {
+      const { name, description, location, url } = req.body;
+      const activity = await prisma.activity.create({
+        data: { name, description, location, url }
+      });
+      return res.status(201).json(activity);
+    } catch (error) {
+      console.error('Error creating activity:', error);
+      return res.status(500).json({ message: 'Failed to create activity' });
+    }
   }
   res.status(405).json({ message: 'Method not allowed' });
 }

--- a/aspen_site/pages/api/advertisements.ts
+++ b/aspen_site/pages/api/advertisements.ts
@@ -1,16 +1,26 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    const advertisements = await prisma.advertisement.findMany();
-    return res.status(200).json(advertisements);
+    try {
+      const advertisements = await prisma.advertisement.findMany();
+      return res.status(200).json(advertisements);
+    } catch (error) {
+      console.error('Error fetching advertisements:', error);
+      return res.status(500).json({ message: 'Failed to fetch advertisements' });
+    }
   } else if (req.method === 'POST') {
-    const { title, description, imageUrl, link } = req.body;
-    const ad = await prisma.advertisement.create({
-      data: { title, description, imageUrl, link }
-    });
-    return res.status(201).json(ad);
+    try {
+      const { title, description, imageUrl, link } = req.body;
+      const ad = await prisma.advertisement.create({
+        data: { title, description, imageUrl, link }
+      });
+      return res.status(201).json(ad);
+    } catch (error) {
+      console.error('Error creating advertisement:', error);
+      return res.status(500).json({ message: 'Failed to create advertisement' });
+    }
   }
   res.status(405).json({ message: 'Method not allowed' });
 }

--- a/aspen_site/pages/api/restaurants.ts
+++ b/aspen_site/pages/api/restaurants.ts
@@ -1,16 +1,26 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
+import { prisma } from '@/lib/prisma';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    const restaurants = await prisma.restaurant.findMany();
-    return res.status(200).json(restaurants);
+    try {
+      const restaurants = await prisma.restaurant.findMany();
+      return res.status(200).json(restaurants);
+    } catch (error) {
+      console.error('Error fetching restaurants:', error);
+      return res.status(500).json({ message: 'Failed to fetch restaurants' });
+    }
   } else if (req.method === 'POST') {
-    const { name, description, location, url } = req.body;
-    const restaurant = await prisma.restaurant.create({
-      data: { name, description, location, url }
-    });
-    return res.status(201).json(restaurant);
+    try {
+      const { name, description, location, url } = req.body;
+      const restaurant = await prisma.restaurant.create({
+        data: { name, description, location, url }
+      });
+      return res.status(201).json(restaurant);
+    } catch (error) {
+      console.error('Error creating restaurant:', error);
+      return res.status(500).json({ message: 'Failed to create restaurant' });
+    }
   }
   res.status(405).json({ message: 'Method not allowed' });
 }


### PR DESCRIPTION
## Summary
- handle Prisma errors in activities API routes
- handle Prisma errors in advertisements API routes
- handle Prisma errors in restaurants API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm install --save-dev @types/jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be3cdde70c8322bff52336629de451