### PR TITLE
Define shared interfaces and apply to pages

### DIFF
--- a/aspen_site/lib/types.ts
+++ b/aspen_site/lib/types.ts
@@ -1,0 +1,23 @@
+export interface Restaurant {
+  id: number;
+  name: string;
+  description: string;
+  location?: string | null;
+  url?: string | null;
+}
+
+export interface Activity {
+  id: number;
+  name: string;
+  description: string;
+  location?: string | null;
+  url?: string | null;
+}
+
+export interface Advertisement {
+  id: number;
+  title: string;
+  description: string;
+  imageUrl?: string | null;
+  link?: string | null;
+}

--- a/aspen_site/next-env.d.ts
+++ b/aspen_site/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/aspen_site/pages/advertise/[id].tsx
+++ b/aspen_site/pages/advertise/[id].tsx
@@ -1,7 +1,12 @@
 import { GetServerSideProps } from 'next';
 import { prisma } from '../../lib/prisma';
+import { Advertisement } from '@/lib/types';
 
-export default function Ad({ advertisement }: { advertisement: any }) {
+interface AdProps {
+  advertisement: Advertisement | null;
+}
+
+export default function Ad({ advertisement }: AdProps) {
   if (!advertisement) {
     return <div>Advertisement not found</div>;
   }
@@ -21,8 +26,8 @@ export default function Ad({ advertisement }: { advertisement: any }) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<AdProps> = async (context) => {
   const { id } = context.params!;
   const advertisement = await prisma.advertisement.findUnique({ where: { id: Number(id) } });
-  return { props: { advertisement: advertisement || null } };
+  return { props: { advertisement } };
 };

--- a/aspen_site/pages/eat/[id].tsx
+++ b/aspen_site/pages/eat/[id].tsx
@@ -1,7 +1,12 @@
 import { GetServerSideProps } from 'next';
 import { prisma } from '../../lib/prisma';
+import { Restaurant } from '@/lib/types';
 
-export default function Eat({ restaurant }: { restaurant: any }) {
+interface EatProps {
+  restaurant: Restaurant | null;
+}
+
+export default function Eat({ restaurant }: EatProps) {
   if (!restaurant) {
     return <div>Restaurant not found</div>;
   }
@@ -19,8 +24,8 @@ export default function Eat({ restaurant }: { restaurant: any }) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<EatProps> = async (context) => {
   const { id } = context.params!;
   const restaurant = await prisma.restaurant.findUnique({ where: { id: Number(id) } });
-  return { props: { restaurant: restaurant || null } };
+  return { props: { restaurant } };
 };

--- a/aspen_site/pages/fun/[id].tsx
+++ b/aspen_site/pages/fun/[id].tsx
@@ -1,7 +1,12 @@
 import { GetServerSideProps } from 'next';
 import { prisma } from '../../lib/prisma';
+import { Activity } from '@/lib/types';
 
-export default function Fun({ activity }: { activity: any }) {
+interface FunProps {
+  activity: Activity | null;
+}
+
+export default function Fun({ activity }: FunProps) {
   if (!activity) {
     return <div>Activity not found</div>;
   }
@@ -19,8 +24,8 @@ export default function Fun({ activity }: { activity: any }) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<FunProps> = async (context) => {
   const { id } = context.params!;
   const activity = await prisma.activity.findUnique({ where: { id: Number(id) } });
-  return { props: { activity: activity || null } };
+  return { props: { activity } };
 };

--- a/aspen_site/pages/index.tsx
+++ b/aspen_site/pages/index.tsx
@@ -1,15 +1,22 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { Restaurant, Activity, Advertisement } from '@/lib/types';
 
 export default function Home() {
-  const [restaurants, setRestaurants] = useState([]);
-  const [activities, setActivities] = useState([]);
-  const [ads, setAds] = useState([]);
+  const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [ads, setAds] = useState<Advertisement[]>([]);
 
   useEffect(() => {
-    fetch('/api/restaurants').then(res => res.json()).then(setRestaurants);
-    fetch('/api/activities').then(res => res.json()).then(setActivities);
-    fetch('/api/advertisements').then(res => res.json()).then(setAds);
+    fetch('/api/restaurants')
+      .then(res => res.json())
+      .then((data: Restaurant[]) => setRestaurants(data));
+    fetch('/api/activities')
+      .then(res => res.json())
+      .then((data: Activity[]) => setActivities(data));
+    fetch('/api/advertisements')
+      .then(res => res.json())
+      .then((data: Advertisement[]) => setAds(data));
   }, []);
 
   return (
@@ -17,7 +24,7 @@ export default function Home() {
       <h1 className="text-3xl font-bold mb-4">Welcome to Aspen Adventures & Dining</h1>
       <h2 className="text-xl font-semibold mb-2">Explore Restaurants</h2>
       <ul className="mb-4">
-        {restaurants.map((r: any) => (
+        {restaurants.map(r => (
           <li key={r.id} className="mb-2">
             <Link href={`/eat/${r.id}`}>
               {r.name}
@@ -27,7 +34,7 @@ export default function Home() {
       </ul>
       <h2 className="text-xl font-semibold mb-2">Fun Things to Do</h2>
       <ul className="mb-4">
-        {activities.map((a: any) => (
+        {activities.map(a => (
           <li key={a.id} className="mb-2">
             <Link href={`/fun/${a.id}`}>
               {a.name}
@@ -37,7 +44,7 @@ export default function Home() {
       </ul>
       <h2 className="text-xl font-semibold mb-2">Advertisements</h2>
       <ul>
-        {ads.map((ad: any) => (
+        {ads.map(ad => (
           <li key={ad.id} className="mb-2">
             <Link href={`/advertise/${ad.id}`}>
               {ad.title}


### PR DESCRIPTION
## Summary
- add shared Restaurant, Activity, and Advertisement interfaces
- type index and detail pages using the shared interfaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '../../../lib/prisma' in pages/api/activities.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be3d0880848322b82434325ac5db02