### PR TITLE
Add gitignore to ignore Node build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/node_modules
+**/.next
+out
+.env
+npm-debug.log*


### PR DESCRIPTION
## Summary
- add repo-wide gitignore for node_modules and Next.js build directories

## Testing
- `npm run build` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be4b680c448322a8a5aaa29a08d0fe